### PR TITLE
Ensure buttons remain within card boundaries

### DIFF
--- a/src/web/public/style.css
+++ b/src/web/public/style.css
@@ -81,6 +81,10 @@ nav a:hover, nav a.active {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: 1.25rem 1.5rem;
+  /* Ensure interactive controls remain visually contained inside the card
+     and don't overflow into neighbouring cards */
+  position: relative;
+  overflow: hidden;
   margin-bottom: 0.75rem;
 }
 
@@ -106,6 +110,10 @@ nav a:hover, nav a.active {
   display: flex;
   gap: 0.5rem;
   margin-top: 1rem;
+  align-items: center;
+  /* Allow buttons to wrap onto a new line so they stay inside the card
+     instead of overflowing when space is constrained. */
+  flex-wrap: wrap;
 }
 
 /* ── Buttons ──────────────────────────────────────────────────────────────── */

--- a/src/web/public/style.css
+++ b/src/web/public/style.css
@@ -81,10 +81,8 @@ nav a:hover, nav a.active {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: 1.25rem 1.5rem;
-  /* Ensure interactive controls remain visually contained inside the card
-     and don't overflow into neighbouring cards */
+  /* Ensure interactive controls remain visually contained inside the card */
   position: relative;
-  overflow: hidden;
   margin-bottom: 0.75rem;
 }
 

--- a/src/web/public/style.css
+++ b/src/web/public/style.css
@@ -81,10 +81,9 @@ nav a:hover, nav a.active {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: 1.25rem 1.5rem;
-  /* Ensure interactive controls remain visually contained inside the card */
-  position: relative;
+  /* Keep card content positioned normally without clipping descendant focus
+     indicators such as outlines and box-shadows near the card edge */
   margin-bottom: 0.75rem;
-}
 
 .card-grid {
   display: grid;


### PR DESCRIPTION
Adjust styles to prevent buttons from overflowing their card container, ensuring a cleaner layout.