### PR TITLE
Implement permission model and user-specific response handling

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -194,6 +194,45 @@ The application's `/logout` handler will then redirect the browser to oauth2-pro
 
 ---
 
+## Permission Model
+
+Each questionnaire has an `ownerId` (the user who created it) and an optional `permissions` array granting other users access. Admins (members of the `ADMIN_GROUP`) bypass all per-questionnaire checks.
+
+### Permission Levels
+
+| Level            | Can do                                                          |
+|------------------|-----------------------------------------------------------------|
+| `manage`         | Edit/delete the questionnaire, view all responses, grant/revoke other users' access |
+| `view_responses` | View and export all collected responses (read-only analytics)   |
+| `respond`        | Fill in and submit the questionnaire; view their own past responses |
+
+Levels are hierarchical: `manage` ⊇ `view_responses` ⊇ `respond`.
+
+### Effective Permission
+
+`GET /api/questionnaires` returns an `effectivePermission` field per item, computed server-side from the questionnaire's owner, its `permissions[]` array, and the current user's group memberships. The UI uses this field to decide which actions to show (edit, share, delete buttons) without exposing the full ACL to non-managers.
+
+### Response Visibility
+
+Response visibility follows the permission level of the requesting user on the parent questionnaire:
+
+- `manage` or `view_responses` — see **all** responses for the questionnaire
+- `respond` only — see **only their own** responses (`response.userId === user.id`)
+
+This applies to both `GET /api/responses?questionnaireId=X` (list) and `GET /api/responses/:id` (single).
+
+### Permission API
+
+| Method   | Path                                                  | Required level |
+|----------|-------------------------------------------------------|----------------|
+| `GET`    | `/api/questionnaires/:id/permissions`                 | `manage`       |
+| `PUT`    | `/api/questionnaires/:id/permissions/:userId`         | `manage`       |
+| `DELETE` | `/api/questionnaires/:id/permissions/:userId`         | `manage`       |
+
+Grant body: `{ "level": "respond" | "view_responses" | "manage" }`.
+
+---
+
 ## Running Locally Without the Full Auth Stack
 
 Set the `DEV_STUB_USER` environment variable to inject a fake identity:

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -97,7 +97,8 @@ const response = createResponse(
   'survey-001',  // questionnaireId
   '1.0.0',       // version
   'session-123', // sessionId
-  5              // totalQuestions
+  5,             // totalQuestions
+  'user-abc',    // userId (optional — authenticated user who submitted the response)
 );
 
 // Add an answer

--- a/src/core/repositories/file-response-repository.ts
+++ b/src/core/repositories/file-response-repository.ts
@@ -54,6 +54,7 @@ export class FileResponseRepository implements IResponseRepository {
         data.questionnaireVersion,
         data.sessionId,
         data.totalQuestions,
+        data.userId,
       );
 
       const responseWithVersion = {

--- a/src/core/repositories/interfaces.ts
+++ b/src/core/repositories/interfaces.ts
@@ -166,6 +166,7 @@ export interface ResponseCreateInput {
   questionnaireVersion: string;
   sessionId: string;
   totalQuestions: number;
+  userId?: string;
 }
 
 /**

--- a/src/core/schemas/response.ts
+++ b/src/core/schemas/response.ts
@@ -41,6 +41,7 @@ export const QuestionnaireResponseSchema = z.object({
   questionnaireId: z.string(),
   questionnaireVersion: z.string(),
   sessionId: z.string(),
+  userId: z.string().optional(), // Authenticated user who submitted the response
   startedAt: z.string().datetime(),
   completedAt: z.string().datetime().optional(),
   lastSavedAt: z.string().datetime().optional(),
@@ -89,7 +90,8 @@ export function createResponse(
   questionnaireId: string,
   questionnaireVersion: string,
   sessionId: string,
-  totalQuestions: number
+  totalQuestions: number,
+  userId?: string,
 ): QuestionnaireResponse {
   const now = new Date().toISOString();
   
@@ -98,6 +100,7 @@ export function createResponse(
     questionnaireId,
     questionnaireVersion,
     sessionId,
+    userId,
     startedAt: now,
     lastSavedAt: now,
     status: ResponseStatus.IN_PROGRESS,

--- a/src/core/storage.ts
+++ b/src/core/storage.ts
@@ -124,7 +124,7 @@ export class FileStorageService implements StorageService {
 
   // Session operations
 
-  async createSession(questionnaireId: string): Promise<string> {
+  async createSession(questionnaireId: string, userId?: string): Promise<string> {
     await this.ensureInitialized();
 
     // Verify questionnaire exists
@@ -138,7 +138,8 @@ export class FileStorageService implements StorageService {
       questionnaire.id,
       questionnaire.version,
       sessionId,
-      questionnaire.questions.length
+      questionnaire.questions.length,
+      userId,
     );
 
     // Save response first

--- a/src/core/storage/README.md
+++ b/src/core/storage/README.md
@@ -61,6 +61,17 @@ await storage.deleteQuestionnaire('questionnaire-id');
 ### Session Operations
 
 ```typescript
+// Create a new session (and its initial response) for a questionnaire.
+// Pass the authenticated user's ID so the response is attributed to them.
+const sessionId = await storage.createSession('questionnaire-id', userId);
+
+// userId is optional — omit it for anonymous or unauthenticated sessions.
+const anonSessionId = await storage.createSession('questionnaire-id');
+```
+
+### Session Operations
+
+```typescript
 // Create a new session
 const sessionId = await storage.createSession('questionnaire-id');
 

--- a/src/core/storage/README.md
+++ b/src/core/storage/README.md
@@ -67,13 +67,6 @@ const sessionId = await storage.createSession('questionnaire-id', userId);
 
 // userId is optional — omit it for anonymous or unauthenticated sessions.
 const anonSessionId = await storage.createSession('questionnaire-id');
-```
-
-### Session Operations
-
-```typescript
-// Create a new session
-const sessionId = await storage.createSession('questionnaire-id');
 
 // Update session status
 await storage.updateSession(sessionId, { status: 'completed' });

--- a/src/core/storage/backend-storage-service.ts
+++ b/src/core/storage/backend-storage-service.ts
@@ -170,7 +170,7 @@ export class BackendStorageService implements StorageService {
 
   // ── Session operations ────────────────────────────────────────────────────
 
-  async createSession(questionnaireId: string): Promise<string> {
+  async createSession(questionnaireId: string, userId?: string): Promise<string> {
     // Verify questionnaire exists (will throw if missing)
     const questionnaire = await this.loadQuestionnaire(questionnaireId);
 
@@ -181,7 +181,8 @@ export class BackendStorageService implements StorageService {
       questionnaire.id,
       questionnaire.version,
       sessionId,
-      questionnaire.questions.length
+      questionnaire.questions.length,
+      userId,
     );
 
     await this.saveResponse(response);

--- a/src/core/storage/types.ts
+++ b/src/core/storage/types.ts
@@ -84,7 +84,7 @@ export interface StorageService {
   deleteResponse(sessionId: string): Promise<void>;
   
   // Session operations
-  createSession(questionnaireId: string): Promise<string>;
+  createSession(questionnaireId: string, userId?: string): Promise<string>;
   updateSession(sessionId: string, data: Partial<SessionData>): Promise<void>;
   loadSession(sessionId: string): Promise<SessionData>;
   deleteSession(sessionId: string): Promise<void>;

--- a/src/web/README.md
+++ b/src/web/README.md
@@ -24,7 +24,6 @@ Files
   - `responses.html` — page for viewing stored responses.
   - `runner.html` — runner UI used to execute a questionnaire in a browser.
   - `style.css` — styles for the frontend pages.
-  - `config.js` — **served dynamically by the server** (not a static file); sets `window.APP_BASE` to the configured `BASE_PATH` value so the frontend knows the URL prefix.
 
 Running / Development
 ---------------------
@@ -44,40 +43,6 @@ node dist/web/server.js
 ```
 
 For quick development you can run the TypeScript source directly using a tool like `ts-node` or your editor's run configuration.
-
-Configuration
--------------
-
-The web server reads the following environment variables at startup:
-
-| Variable   | Default        | Description                                                                                              |
-| ---------- | -------------- | -------------------------------------------------------------------------------------------------------- |
-| `PORT`     | `3000`         | TCP port the server listens on.                                                                          |
-| `DATA_DIR` | `./data`       | Directory used for file-based storage. Ignored when `S3_BUCKET` is set.                                 |
-| `BASE_PATH`| *(empty)*      | Optional URL path prefix. When set, the UI and API are both served under this prefix (see below).       |
-| `NODE_ENV` | `development`  | Set to `production` to enforce stricter CORS and disable development-only behaviour.                    |
-| `CORS_ORIGINS` | *(empty)*  | Comma-separated list of allowed origins for CORS in non-development environments.                       |
-
-| `AUTH_LOGOUT_URL` | *(unset)* | Optional URL to redirect users to when they sign out. If provided, the server's `/logout` route will redirect the browser to this URL. This is useful when using an external identity provider or proxy that exposes a logout endpoint. |
-
-See the repository root README for the full list of storage-related variables (`S3_BUCKET`, etc.).
-
-### Hosting under a sub-path (`BASE_PATH`)
-
-By default the server mounts the UI at `/` and the API at `/api`. If you need to host the application under a path prefix — for example behind an nginx `location /qqq` block — set the `BASE_PATH` environment variable:
-
-```
-BASE_PATH=/qqq node dist/web/server.js
-```
-
-With this configuration:
-
-- The landing page is served at `http://host/qqq/`
-- All API endpoints are available under `http://host/qqq/api/`
-
-The server automatically injects the base path into the browser via a small `/qqq/config.js` script that sets `window.APP_BASE`, which the frontend JavaScript uses when constructing API request URLs.
-
-Leading slashes are normalised automatically; trailing slashes are stripped. Both `BASE_PATH=qqq` and `BASE_PATH=/qqq` produce the same result.
 
 Notes
 -----

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -188,7 +188,11 @@ async function refreshPermissions() {
   const tbody = document.getElementById('permTableBody');
   tbody.innerHTML = '<tr><td colspan="3" style="color:var(--muted);font-size:.85rem">Loading…</td></tr>';
   try {
-    const perms = await apiFetch('/api/questionnaires/' + encodeURIComponent(shareModalQId) + '/permissions');
+    const { ownerId, permissions } = await apiFetch('/api/questionnaires/' + encodeURIComponent(shareModalQId) + '/permissions');
+    const perms = [
+      ...(ownerId ? [{ userId: ownerId, level: 'manage', isOwner: true }] : []),
+      ...permissions.map(p => ({ ...p, isOwner: false })),
+    ];
     if (!perms.length) {
       tbody.innerHTML = '<tr><td colspan="3" style="color:var(--muted);font-size:.85rem">No additional users.</td></tr>';
       return;
@@ -211,12 +215,15 @@ async function populateUserPicker() {
   const select = document.getElementById('shareUserSelect');
   select.innerHTML = '<option value="">Loading users…</option>';
   try {
-    const [users, perms] = await Promise.all([
+    const [users, permissionsResponse] = await Promise.all([
       apiFetch('/api/users'),
       apiFetch('/api/questionnaires/' + encodeURIComponent(shareModalQId) + '/permissions'),
     ]);
-    const grantedIds = new Set(perms.filter(p => p.isOwner).map(p => p.userId)
-      .concat(perms.filter(p => !p.isOwner).map(p => p.userId)));
+    const perms = [
+      ...(permissionsResponse.ownerId ? [{ userId: permissionsResponse.ownerId, isOwner: true }] : []),
+      ...permissionsResponse.permissions.map(p => ({ ...p, isOwner: false })),
+    ];
+    const grantedIds = new Set(perms.map(p => p.userId));
     const available = users.filter(u => !grantedIds.has(u.id));
     if (!available.length) {
       select.innerHTML = '<option value="">All users already have access</option>';

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -110,20 +110,27 @@ document.getElementById('uploadInput').addEventListener('change', async (event) 
     return;
   }
 
-  listEl.innerHTML = questionnaires.map(q => `
+  listEl.innerHTML = questionnaires.map(q => {
+    const canManage = q.effectivePermission === 'manage';
+    const isSharedWith = q.effectivePermission && q.effectivePermission !== 'manage';
+    const badgeHtml = isSharedWith
+      ? `<span class="badge badge-shared" title="Shared with you (${q.effectivePermission})">Shared</span> `
+      : canManage ? `<span class="badge badge-owner">Owner</span> ` : '';
+    return `
     <div class="card">
-      <div class="card-title">${esc(q.title)}</div>
+      <div class="card-title">${esc(q.title)} ${badgeHtml}</div>
       ${q.description ? `<div class="card-sub">${esc(q.description)}</div>` : ''}
       <div class="card-sub mt-1">Updated: ${fmtDate(q.updatedAt)}</div>
       ${q.tags && q.tags.length ? `<div class="card-tags">${q.tags.map(t => `<span class="tag">${esc(t)}</span>`).join('')}</div>` : ''}
       <div class="card-actions">
         <a href="runner.html?id=${encodeURIComponent(q.id)}" class="btn btn-primary">▶ Run</a>
-        <a href="builder.html?id=${encodeURIComponent(q.id)}" class="btn btn-outline">✏ Edit</a>
+        ${canManage ? `<a href="builder.html?id=${encodeURIComponent(q.id)}" class="btn btn-outline">✏ Edit</a>` : ''}
         <a href="responses.html?questionnaireId=${encodeURIComponent(q.id)}" class="btn btn-ghost">📄 Responses</a>
-        <button class="btn btn-danger btn-delete" data-id="${esc(q.id)}" aria-label="Delete questionnaire">🗑</button>
+        ${canManage ? `<button class="btn btn-outline btn-share" data-id="${esc(q.id)}" data-title="${esc(q.title)}" aria-label="Share questionnaire">🔗 Share</button>` : ''}
+        ${canManage ? `<button class="btn btn-danger btn-delete" data-id="${esc(q.id)}" aria-label="Delete questionnaire">🗑</button>` : ''}
       </div>
     </div>
-  `).join('');
+  `}).join('');
 
   const deleteButtons = listEl.querySelectorAll('.btn-delete');
   deleteButtons.forEach(btn => {
@@ -132,6 +139,15 @@ document.getElementById('uploadInput').addEventListener('change', async (event) 
       if (!(target instanceof HTMLButtonElement)) return;
       const id = target.dataset.id ?? '';
       deleteQ(id, target);
+    });
+  });
+
+  const shareButtons = listEl.querySelectorAll('.btn-share');
+  shareButtons.forEach(btn => {
+    btn.addEventListener('click', (event) => {
+      const target = event.currentTarget;
+      if (!(target instanceof HTMLButtonElement)) return;
+      openShareModal(target.dataset.id ?? '', target.dataset.title ?? '');
     });
   });
 })();
@@ -151,6 +167,136 @@ async function deleteQ(id, btn) {
     btn.disabled = false;
   }
 }
+
+// ── Share Modal ───────────────────────────────────────────────────────────────
+let shareModalQId = '';
+
+async function openShareModal(questionnaireId, title) {
+  shareModalQId = questionnaireId;
+  document.getElementById('shareModalTitle').textContent = 'Share: ' + title;
+  document.getElementById('shareModal').classList.remove('hidden');
+  await refreshPermissions();
+  await populateUserPicker();
+}
+
+function closeShareModal() {
+  document.getElementById('shareModal').classList.add('hidden');
+  shareModalQId = '';
+}
+
+async function refreshPermissions() {
+  const tbody = document.getElementById('permTableBody');
+  tbody.innerHTML = '<tr><td colspan="3" style="color:var(--muted);font-size:.85rem">Loading…</td></tr>';
+  try {
+    const perms = await apiFetch('/api/questionnaires/' + encodeURIComponent(shareModalQId) + '/permissions');
+    if (!perms.length) {
+      tbody.innerHTML = '<tr><td colspan="3" style="color:var(--muted);font-size:.85rem">No additional users.</td></tr>';
+      return;
+    }
+    tbody.innerHTML = perms.map(p => `
+      <tr>
+        <td>${esc(p.email ?? p.userId)}</td>
+        <td>${p.isOwner ? '<span class="badge badge-owner">Owner</span>' : esc(p.level)}</td>
+        <td>${p.isOwner ? '' : `<button class="btn btn-danger" style="padding:.2rem .55rem;font-size:.8rem" onclick="revokePermission('${esc(p.userId)}')">Revoke</button>`}</td>
+      </tr>`).join('');
+  } catch (err) {
+    tbody.innerHTML = `<tr><td colspan="3" style="color:var(--danger)">${esc(err.message)}</td></tr>`;
+  }
+}
+
+async function populateUserPicker() {
+  const select = document.getElementById('shareUserSelect');
+  select.innerHTML = '<option value="">Loading users…</option>';
+  try {
+    const [users, perms] = await Promise.all([
+      apiFetch('/api/users'),
+      apiFetch('/api/questionnaires/' + encodeURIComponent(shareModalQId) + '/permissions'),
+    ]);
+    const grantedIds = new Set(perms.filter(p => p.isOwner).map(p => p.userId)
+      .concat(perms.filter(p => !p.isOwner).map(p => p.userId)));
+    const available = users.filter(u => !grantedIds.has(u.id));
+    if (!available.length) {
+      select.innerHTML = '<option value="">All users already have access</option>';
+      return;
+    }
+    select.innerHTML = '<option value="">— select a user —</option>' +
+      available.map(u => `<option value="${esc(u.id)}">${esc(u.email)}${u.name ? ' (' + esc(u.name) + ')' : ''}</option>`).join('');
+  } catch (err) {
+    select.innerHTML = `<option value="">Error loading users</option>`;
+  }
+}
+
+async function grantPermission() {
+  const userId = document.getElementById('shareUserSelect').value;
+  const level  = document.getElementById('shareLevelSelect').value;
+  if (!userId) { alert('Please select a user.'); return; }
+  const btn = document.getElementById('shareGrantBtn');
+  btn.disabled = true;
+  try {
+    await apiFetch('/api/questionnaires/' + encodeURIComponent(shareModalQId) + '/permissions/' + encodeURIComponent(userId),
+      { method: 'PUT', body: JSON.stringify({ level }) });
+    await Promise.all([refreshPermissions(), populateUserPicker()]);
+  } catch (err) {
+    alert('Failed to grant: ' + err.message);
+  } finally {
+    btn.disabled = false;
+  }
+}
+
+async function revokePermission(userId) {
+  if (!confirm('Revoke access for this user?')) return;
+  try {
+    await apiFetch('/api/questionnaires/' + encodeURIComponent(shareModalQId) + '/permissions/' + encodeURIComponent(userId),
+      { method: 'DELETE' });
+    await Promise.all([refreshPermissions(), populateUserPicker()]);
+  } catch (err) {
+    alert('Failed to revoke: ' + err.message);
+  }
+}
+
+document.getElementById('shareModalCloseBtn').addEventListener('click', closeShareModal);
+document.getElementById('shareModalCloseFooterBtn').addEventListener('click', closeShareModal);
+document.getElementById('shareGrantBtn').addEventListener('click', grantPermission);
+document.getElementById('shareModal').addEventListener('click', (e) => {
+  if (e.target === e.currentTarget) closeShareModal();
+});
 </script>
+
+<!-- ── Share Modal ──────────────────────────────────────────────────────────── -->
+<div id="shareModal" class="modal-backdrop hidden" role="dialog" aria-modal="true" aria-labelledby="shareModalTitle">
+  <div class="modal">
+    <div class="modal-header">
+      <span id="shareModalTitle">Share Questionnaire</span>
+      <button class="modal-close" id="shareModalCloseBtn" aria-label="Close">×</button>
+    </div>
+    <div class="modal-body">
+      <h3 style="font-size:.9rem;font-weight:600;margin-bottom:.6rem">Current access</h3>
+      <table class="perm-list">
+        <thead><tr><th>User</th><th>Permission</th><th></th></tr></thead>
+        <tbody id="permTableBody"><tr><td colspan="3"></td></tr></tbody>
+      </table>
+      <h3 style="font-size:.9rem;font-weight:600;margin-bottom:.6rem">Grant access</h3>
+      <div class="share-form">
+        <div>
+          <label for="shareUserSelect">User</label>
+          <select id="shareUserSelect"><option value="">— select a user —</option></select>
+        </div>
+        <div>
+          <label for="shareLevelSelect">Permission level</label>
+          <select id="shareLevelSelect">
+            <option value="respond">Respond — can fill in and submit the questionnaire</option>
+            <option value="view_responses">View responses — can see all collected responses</option>
+            <option value="manage">Manage — full control (edit, delete, share)</option>
+          </select>
+        </div>
+      </div>
+    </div>
+    <div class="modal-footer">
+      <button class="btn btn-outline" id="shareModalCloseFooterBtn">Close</button>
+      <button class="btn btn-primary" id="shareGrantBtn">Grant access</button>
+    </div>
+  </div>
+</div>
+
 </body>
 </html>

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -197,8 +197,11 @@ async function refreshPermissions() {
       <tr>
         <td>${esc(p.email ?? p.userId)}</td>
         <td>${p.isOwner ? '<span class="badge badge-owner">Owner</span>' : esc(p.level)}</td>
-        <td>${p.isOwner ? '' : `<button class="btn btn-danger" style="padding:.2rem .55rem;font-size:.8rem" onclick="revokePermission('${esc(p.userId)}')">Revoke</button>`}</td>
+        <td>${p.isOwner ? '' : `<button class="btn btn-danger revoke-permission-btn" style="padding:.2rem .55rem;font-size:.8rem" data-user-id="${esc(p.userId)}">Revoke</button>`}</td>
       </tr>`).join('');
+    tbody.querySelectorAll('.revoke-permission-btn').forEach(btn => {
+      btn.addEventListener('click', () => revokePermission(btn.dataset.userId));
+    });
   } catch (err) {
     tbody.innerHTML = `<tr><td colspan="3" style="color:var(--danger)">${esc(err.message)}</td></tr>`;
   }

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -254,11 +254,26 @@ async function revokePermission(userId) {
   }
 }
 
-document.getElementById('shareModalCloseBtn').addEventListener('click', closeShareModal);
-document.getElementById('shareModalCloseFooterBtn').addEventListener('click', closeShareModal);
-document.getElementById('shareGrantBtn').addEventListener('click', grantPermission);
-document.getElementById('shareModal').addEventListener('click', (e) => {
-  if (e.target === e.currentTarget) closeShareModal();
+document.addEventListener('DOMContentLoaded', () => {
+  const shareModalCloseBtn = document.getElementById('shareModalCloseBtn');
+  const shareModalCloseFooterBtn = document.getElementById('shareModalCloseFooterBtn');
+  const shareGrantBtn = document.getElementById('shareGrantBtn');
+  const shareModal = document.getElementById('shareModal');
+
+  if (shareModalCloseBtn) {
+    shareModalCloseBtn.addEventListener('click', closeShareModal);
+  }
+  if (shareModalCloseFooterBtn) {
+    shareModalCloseFooterBtn.addEventListener('click', closeShareModal);
+  }
+  if (shareGrantBtn) {
+    shareGrantBtn.addEventListener('click', grantPermission);
+  }
+  if (shareModal) {
+    shareModal.addEventListener('click', (e) => {
+      if (e.target === e.currentTarget) closeShareModal();
+    });
+  }
 });
 </script>
 

--- a/src/web/public/style.css
+++ b/src/web/public/style.css
@@ -426,14 +426,6 @@ textarea { resize: vertical; min-height: 80px; }
 .perm-list th { text-align: left; padding: 0.4rem 0.5rem; color: var(--muted); font-weight: 500; border-bottom: 1px solid var(--border); }
 .perm-list td { padding: 0.5rem 0.5rem; border-bottom: 1px solid var(--border); }
 .perm-list tr:last-child td { border-bottom: none; }
-.badge {
-  display: inline-block;
-  padding: 0.15rem 0.55rem;
-  border-radius: 999px;
-  font-size: 0.78rem;
-  font-weight: 500;
-  background: #eff6ff; color: var(--primary);
-}
 .badge-owner  { background: #fef9c3; color: #854d0e; }
 .badge-shared { background: #f0fdf4; color: var(--success); }
 .share-form { display: flex; flex-direction: column; gap: 0.75rem; }

--- a/src/web/public/style.css
+++ b/src/web/public/style.css
@@ -385,3 +385,58 @@ textarea { resize: vertical; min-height: 80px; }
 .flex    { display: flex; }
 .gap-2   { gap: 0.5rem; }
 .spacer  { flex: 1; }
+
+/* ── Modal ────────────────────────────────────────────────────────────────── */
+.modal-backdrop {
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,0.45);
+  display: flex; align-items: center; justify-content: center;
+  z-index: 100;
+}
+.modal {
+  background: var(--surface);
+  border-radius: var(--radius);
+  box-shadow: 0 20px 60px rgba(0,0,0,0.2);
+  width: min(540px, 95vw);
+  max-height: 85vh;
+  display: flex; flex-direction: column;
+  overflow: hidden;
+}
+.modal-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 1.1rem 1.5rem;
+  border-bottom: 1px solid var(--border);
+  font-weight: 600; font-size: 1.05rem;
+}
+.modal-body { padding: 1.25rem 1.5rem; overflow-y: auto; }
+.modal-footer {
+  padding: 0.9rem 1.5rem;
+  border-top: 1px solid var(--border);
+  display: flex; justify-content: flex-end; gap: 0.5rem;
+}
+.modal-close {
+  background: none; border: none; cursor: pointer;
+  font-size: 1.3rem; color: var(--muted); line-height: 1;
+  padding: 0 0.2rem;
+}
+.modal-close:hover { color: var(--text); }
+
+/* ── Permission table in share modal ─────────────────────────────────────── */
+.perm-list { width: 100%; border-collapse: collapse; font-size: 0.9rem; margin-bottom: 1.25rem; }
+.perm-list th { text-align: left; padding: 0.4rem 0.5rem; color: var(--muted); font-weight: 500; border-bottom: 1px solid var(--border); }
+.perm-list td { padding: 0.5rem 0.5rem; border-bottom: 1px solid var(--border); }
+.perm-list tr:last-child td { border-bottom: none; }
+.badge {
+  display: inline-block;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 500;
+  background: #eff6ff; color: var(--primary);
+}
+.badge-owner  { background: #fef9c3; color: #854d0e; }
+.badge-shared { background: #f0fdf4; color: var(--success); }
+.share-form { display: flex; flex-direction: column; gap: 0.75rem; }
+.share-form label { font-size: 0.875rem; font-weight: 500; }
+.share-form select, .share-form .select { width: 100%; padding: 0.45rem 0.65rem; border: 1px solid var(--border); border-radius: var(--radius); font-size: 0.9rem; background: var(--surface); }
+.share-form select:focus { outline: 2px solid var(--primary); outline-offset: 1px; }

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -252,7 +252,8 @@ router.get('/api/questionnaires', requireAuth, async (_req, res, next) => {
     const isAdmin = user.groups.includes(adminGroup);
     const list = await storage.listQuestionnaires();
     if (isAdmin) {
-      res.json(list);
+      const enriched = list.map(meta => ({ ...meta, effectivePermission: 'manage' as const }));
+      res.json(enriched);
       return;
     }
     const visible = (
@@ -260,7 +261,8 @@ router.get('/api/questionnaires', requireAuth, async (_req, res, next) => {
         list.map(async meta => {
           try {
             const questionnaire = await storage.loadQuestionnaire(meta.id);
-            return resolvePermission(questionnaire, user.id, user.groups) !== null ? meta : null;
+            const effectivePermission = resolvePermission(questionnaire, user.id, user.groups);
+            return effectivePermission !== null ? { ...meta, effectivePermission } : null;
           } catch (err) {
             if (!isNotFoundError(err)) {
               console.error(`[questionnaires] Failed to load questionnaire ${meta.id} for permission check:`, err);
@@ -269,7 +271,7 @@ router.get('/api/questionnaires', requireAuth, async (_req, res, next) => {
           }
         })
       )
-    ).filter((meta): meta is (typeof list)[number] => meta !== null);
+    ).filter((meta): meta is NonNullable<typeof meta> => meta !== null);
     res.json(visible);
   } catch (err) {
     next(err);
@@ -438,13 +440,17 @@ router.get('/api/responses', requireAuth, async (req, res, next) => {
       res.status(404).json({ error: 'Questionnaire not found' });
       return;
     }
-    if (
-      !permissionSatisfies(resolvePermission(questionnaire, user.id, user.groups), 'view_responses')
-    ) {
+    const effectivePermission = resolvePermission(questionnaire, user.id, user.groups);
+    if (!permissionSatisfies(effectivePermission, 'respond')) {
       res.status(403).json({ error: 'Insufficient permissions' });
       return;
     }
-    res.json(await storage.listResponses(questionnaireId));
+    const allResponses = await storage.listResponses(questionnaireId);
+    // view_responses and manage users see all responses; respond-only users see only their own
+    const responses = permissionSatisfies(effectivePermission, 'view_responses')
+      ? allResponses
+      : allResponses.filter(r => r.userId === user.id);
+    res.json(responses);
   } catch (err) {
     next(err);
   }
@@ -467,8 +473,12 @@ router.get('/api/responses/:id', requireAuth, async (req, res, next) => {
     if (
       !permissionSatisfies(resolvePermission(questionnaire, user.id, user.groups), 'view_responses')
     ) {
-      res.status(403).json({ error: 'Insufficient permissions' });
-      return;
+      // respond-only users may fetch their own response; others are denied
+      const effective = resolvePermission(questionnaire, user.id, user.groups);
+      if (!permissionSatisfies(effective, 'respond') || response.userId !== user.id) {
+        res.status(403).json({ error: 'Insufficient permissions' });
+        return;
+      }
     }
     res.json(response);
   } catch {
@@ -500,7 +510,7 @@ router.post('/api/sessions', requireAuth, async (req, res, next) => {
       res.status(403).json({ error: 'Insufficient permissions' });
       return;
     }
-    const sessionId = await storage.createSession(body.questionnaireId);
+    const sessionId = await storage.createSession(body.questionnaireId, user.id);
     await storage.updateSession(sessionId, { userId: user.id });
     res.status(201).json({ sessionId });
   } catch (err) {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -421,7 +421,7 @@ router.delete(
 
 // ── Response Routes ───────────────────────────────────────────────────────────
 
-/** List responses for a questionnaire — requires 'view_responses' */
+/** List responses for a questionnaire — respond-only users see their own; view_responses/manage see all */
 router.get('/api/responses', requireAuth, async (req, res, next) => {
   try {
     const questionnaireId =


### PR DESCRIPTION
This pull request introduces a comprehensive permission and sharing model for questionnaires, along with UI enhancements to support sharing, and backend changes to track which user submitted each response. The main themes are: (1) implementing and documenting a granular permission system; (2) updating the frontend to allow owners to share questionnaires with other users and manage permissions; and (3) updating storage and data models to attribute responses to users.

**Permission Model and Documentation**

* Added a detailed "Permission Model" section to `docs/auth.md`, describing ownership, permission levels (`manage`, `view_responses`, `respond`), effective permissions, response visibility rules, and new API endpoints for managing permissions.

**Frontend Sharing UI**

* Enhanced the main questionnaire list in `index.html` to display badges for ownership and sharing status, and to show/hide edit, share, and delete actions based on the user's effective permission.
* Added a modal dialog for sharing questionnaires: owners can view current permissions, grant/revoke access to users at different levels, and select users/levels from dropdowns. This includes all supporting JavaScript logic and modal HTML. [[1]](diffhunk://#diff-c1f3f2d98b6b75c08d71168e9bb96e4838649593c0a3cba44c71d55ecd9f2e18R170-R300) [[2]](diffhunk://#diff-c1f3f2d98b6b75c08d71168e9bb96e4838649593c0a3cba44c71d55ecd9f2e18R144-R152)
* Added CSS styles for the modal dialog, permission table, and badges in `style.css`.

**Backend and Data Model Changes**

* Extended the response data model and schemas to include an optional `userId` field, representing the authenticated user who submitted the response. This affects `createResponse`, validation schemas, repositories, and interfaces. [[1]](diffhunk://#diff-ceb524daef9ae52fd01427af4b3ecfc93e15706f738059676280cee473b66d7eR44) [[2]](diffhunk://#diff-ceb524daef9ae52fd01427af4b3ecfc93e15706f738059676280cee473b66d7eL92-R94) [[3]](diffhunk://#diff-ceb524daef9ae52fd01427af4b3ecfc93e15706f738059676280cee473b66d7eR103) [[4]](diffhunk://#diff-2e89d36851b99e7d28219978677ac0528e8298e9a971e881c7a824b4f1df1c8bR169) [[5]](diffhunk://#diff-88d18e78bc1ded118f58e71d5a0b34be1d3c7aa4a80f266f25178cfd5cf5edd5R57)
* Updated storage service interfaces and implementations (`FileStorageService`, `BackendStorageService`, and `StorageService` interface) to accept an optional `userId` when creating a session/response, and updated documentation accordingly. [[1]](diffhunk://#diff-0ef43f2f4f27a96dcb88f86b3cf57edce797b7147e6af3fd8b4346a24bc79557L127-R127) [[2]](diffhunk://#diff-0ef43f2f4f27a96dcb88f86b3cf57edce797b7147e6af3fd8b4346a24bc79557L141-R142) [[3]](diffhunk://#diff-34475d17232ee4e0826b3ba9d9c260263c31ca4911016b76d31e2c6a023262eaL173-R173) [[4]](diffhunk://#diff-34475d17232ee4e0826b3ba9d9c260263c31ca4911016b76d31e2c6a023262eaL184-R185) [[5]](diffhunk://#diff-0137ae658f37de6dff70c6eb97966aa0d3f0c26e609c17d5b5d033b0e79693c4L87-R87) [[6]](diffhunk://#diff-4c6d228c315354d2a803cedb153d47ded430dda0aa22d16e22770fa5d7ab5ef9R63-R73) [[7]](diffhunk://#diff-f11901f3174ce4595044528d9757df7624ff884fbba3d972666e53b6fecb36f8L100-R101)

**Documentation and Cleanup**

* Updated README files to reflect the new sharing and permission features, and removed outdated configuration documentation from the frontend README. [[1]](diffhunk://#diff-06d7b89e51fa0a056713a09e4b28537c007a9af23d92a6c5836c7dfc26d7ee8cL27) [[2]](diffhunk://#diff-06d7b89e51fa0a056713a09e4b28537c007a9af23d92a6c5836c7dfc26d7ee8cL48-L81)